### PR TITLE
Problem with maxlength solved.

### DIFF
--- a/jquery.maskMoney.js
+++ b/jquery.maskMoney.js
@@ -67,7 +67,7 @@
 						preventDefault(e);
 						return true;
 					}
-				} else if (input.val().length==input.attr('maxlength')) {
+				} else if (input.val().length>=input.attr('maxlength')) {
 					return false;
 				} else {
 					preventDefault(e);


### PR DESCRIPTION
For example, a field with maxlength = 11 don't work, because the comparision used is "==" and when the input.val().length is 10 and press another number key, they jump to 12 (auto formatted), and the validation don't work. I changed to ">=" operator and now works.
