### PR TITLE
Mask autoloading

### DIFF
--- a/jquery.maskMoney.js
+++ b/jquery.maskMoney.js
@@ -39,7 +39,8 @@
 			precision: 2,
 			defaultZero: true,
 			allowZero: false,
-			allowNegative: false
+			allowNegative: false,
+			autoLoad: false
 		}, settings);
 
 		return this.each(function() {
@@ -280,6 +281,10 @@
 					this.removeEventListener('input',blurEvent,false);
 				}
 			});
+			
+			if (settings.autoLoad){
+			    mask(input);
+			}
 		});
 	}
 


### PR DESCRIPTION
I've created a setting that auto-load the mask on the fields in case the default value of the input is not in the mask's format.

```
$(':text.money').maskMoney({
    thousands:'.', decimal:',', defaultZero: false, autoLoad: true
});
```

After I made this change I realized that i could call also _.maskMoney().mask()_ too :)
