### PR TITLE
compatibility with ie8

### DIFF
--- a/jquery.maskMoney.js
+++ b/jquery.maskMoney.js
@@ -58,7 +58,7 @@
 				e = e||window.event;
 				var k = e.charCode||e.keyCode||e.which;
 				if (k == undefined) return false; //needed to handle an IE "special" event
-				if (input.attr('readonly') && (k!=13&&k!=9)) return false; // don't allow editing of readonly fields but allow tab/enter
+				if (input.prop('readonly') && (k!=13&&k!=9)) return false; // don't allow editing of readonly fields but allow tab/enter
 
 				if (k<48||k>57) { // any key except the numbers 0-9
 					if (k==45) { // -(minus) key
@@ -102,7 +102,7 @@
 				e = e||window.event;
 				var k = e.charCode||e.keyCode||e.which;
 				if (k == undefined) return false; //needed to handle an IE "special" event
-				if (input.attr('readonly') && (k!=13&&k!=9)) return false; // don't allow editing of readonly fields but allow tab/enter
+				if (input.prop('readonly') && (k!=13&&k!=9)) return false; // don't allow editing of readonly fields but allow tab/enter
 
 				var x = input.get(0);
 				var selection = input.getInputSelection(x);


### PR DESCRIPTION
call input.attr('readonly') returns 'readonly' wrong in some cases
