### PR TITLE
Fixing issues with change events (#44)

### DIFF
--- a/jquery.maskMoney.js
+++ b/jquery.maskMoney.js
@@ -65,12 +65,6 @@
 							markAsDirty();
 							input.val(input.val().replace('-',''));
 							return false;
-						} else if (k == 13 || k == 9) { // enter key or tab key
-							if(dirty){
-								clearDirt();
-								$(this).change();
-							}
-							return true;
 						} else if ($.browser.mozilla && (k == 37 || k == 39) && e.charCode == 0) {
 							// needed for left arrow key or right arrow key with firefox
 							// the charCode part is to avoid allowing '%'(e.charCode 0, e.keyCode 37)
@@ -120,12 +114,6 @@
 						maskAndPosition(x, startPos);
 						markAsDirty();
 						return false;
-					} else if (k==9) { // tab key
-						if(dirty) {
-							$(this).change();
-							clearDirt();
-						}
-						return true;
 					} else if ( k==46 || k==63272 ) { // delete key (with special case for safari)
 						preventDefault(e);
 						if(x.selectionStart == x.selectionEnd){
@@ -157,6 +145,7 @@
 						textRange.collapse(false); // set the cursor at the end of the input
 						textRange.select();
 					}
+					this.initialValue = input.val()
 				}
 
 				function blurEvent(e) {
@@ -179,6 +168,12 @@
 							input.val(setSymbol(getDefaultMask()));
 						}
 					}
+
+					if(dirty && this.initialValue !== input.val()) {
+						$(this).change();
+						clearDirt();
+					}
+
 				}
 
 				function preventDefault(e) {


### PR DESCRIPTION
Hi guys! There is a way to fix issues with change events. Since blur is triggering anyways, we can throw out triggering change events on tab and escape keyups and keydowns.

Also, change now is not triggered if user did something(field became dirty), but ended up with the same value.

Sum up:
- Click out from input now triggers change event
- Change not triggered now if the value is the same as it was
