### PR TITLE
Allow maxlength of -1

### DIFF
--- a/jquery.maskMoney.js
+++ b/jquery.maskMoney.js
@@ -79,7 +79,7 @@
 							preventDefault(e);
 							return true;
 						}
-					} else if (input.val().length >= input.attr('maxlength') && input.attr('maxlength') != -1) {
+					} else if (input.val().length >= input.attr('maxlength') && input.attr('maxlength') >= 0) {
 						return false;
 					} else {
 						preventDefault(e);


### PR DESCRIPTION
-1 is a valid value for input maxlength (see: https://developer.mozilla.org/en-US/docs/HTML/Element/Input). When jQuery (1.5 at least, perhaps also in later versions) injects an input element into the DOM, Firefox (v20, OSX) sets the maxlength to -1 (unlimited). This caused maskMoney to think that the input was full because it was doing a greater than check on input.maxlength.

This change checks to see if the maxlength is set to -1 and allows that
