### PR TITLE
fixed case that CHANGE was not triggered if the field loses focus with u...

### DIFF
--- a/jquery.maskMoney.js
+++ b/jquery.maskMoney.js
@@ -187,6 +187,12 @@
 						} else if (settings.symbolStay && input.val() == settings.symbol){
 							input.val(setSymbol(getDefaultMask()));
 						}
+						// We need to trigger change. 
+						// This is the case that user clicks outside of the field and there is a value change
+						if(dirty) {
+							$(this).change();
+							clearDirt();
+						}
 					}
 				}
 


### PR DESCRIPTION
Fixed a little bug:

If I change the field value and leave the field by clicking outside the field (not using TAB or ENTER) the CHANGE event was not triggered. 
