### PR TITLE
Treat empty as zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The options that you can set are:
  * `precision`: how many decimal places are allowed. default: 2
  * `allowZero`: use this setting to prevent users from inputing zero. default: false
  * `allowNegative`: use this setting to prevent users from inputing negative values. default: false
+ * `treatEmptyAsZero`: use this setting to prevent an empty field to mean "0". default: true
 
 __IMPORTANT__: if you try to bind maskMoney to a read only field, nothing will happen, since we ignore completely read only fields. So, if you have a read only field, try to bind maskMoney to it, it will not work. Even if you change the field removing the readonly property, you will need to re-bind maskMoney to make it work.
 
@@ -80,6 +81,7 @@ You can also configure maskMoney options using the data-* API instead of passing
  * [Daniel Loureiro](https://github.com/loureirorg)
  * [Thiago Silva](http://twitter.com/tafs7/)
  * [Guilherme Nagatomo](https://github.com/guilhermehn)
+ * [Eduardo Del Balso](https://github.com/edelbalso)
 
 ***
 ### License:

--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -290,6 +290,11 @@
                         preventDefault(e);
 
                         value = $input.val();
+
+                        if(!settings.treatEmptyAsZero && (value === "" || value === setSymbol(getDefaultMask()) )) {
+                          $input.val("");
+                          return false;
+                        }
                         // not a selection
                         if (startPos === endPos) {
                             // backspace

--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -62,7 +62,8 @@
                 decimal: ".",
                 precision: 2,
                 allowZero: false,
-                allowNegative: false
+                allowNegative: false,
+                treatEmptyAsZero: true
             }, settings);
 
             return this.each(function () {
@@ -319,8 +320,13 @@
                 }
 
                 function focusEvent() {
-                    onFocusValue = $input.val();
-                    mask();
+                    onFocusValue = $input.val().trim();
+                    if (onFocusValue === "" && !settings.treatEmptyAsZero) {
+                      $input.val("");
+                    } else {
+                      mask();
+                    }
+
                     var input = $input.get(0),
                         textRange;
                     if (input.createTextRange) {
@@ -346,14 +352,22 @@
                         keypressEvent(e);
                     }
 
-                    if ($input.val() === "" || $input.val() === setSymbol(getDefaultMask())) {
-                        if (!settings.allowZero) {
+                    if ($input.val() === "") {
+                        if (!settings.allowZero || !settings.treatEmptyAsZero) {
                             $input.val("");
                         } else if (!settings.affixesStay) {
                             $input.val(getDefaultMask());
                         } else {
                             $input.val(setSymbol(getDefaultMask()));
                         }
+                    } else if($input.val() === setSymbol(getDefaultMask())) {
+                      if (!settings.allowZero) {
+                        $input.val("");
+                      } else if (!settings.affixesStay) {
+                        $input.val(getDefaultMask());
+                      } else {
+                        $input.val(setSymbol(getDefaultMask()));
+                      }
                     } else {
                         if (!settings.affixesStay) {
                             var newValue = $input.val().replace(settings.prefix, "").replace(settings.suffix, "");

--- a/test/blur_test.js
+++ b/test/blur_test.js
@@ -1,0 +1,67 @@
+"use strict";
+
+module("blur");
+test("with default mask", function() {
+  var input = $("#input1").maskMoney();
+  input.val("12345678");
+  input.trigger("focus");
+  input.trigger("blur");
+  equal(input.val(), "123,456.78", "format the value of the field on focus");
+});
+
+test("with allowZero set to true", function() {
+  var input = $("#input1").maskMoney({allowZero: true});
+  input.val("0");
+  input.trigger("focus");
+  input.trigger("blur");
+  equal(input.val(), "0.00", "format the value of the field on focus");
+});
+
+test("with allowZero set to false", function() {
+  var input = $("#input1").maskMoney({allowZero: false});
+  input.val("0");
+  input.trigger("focus");
+  input.trigger("blur");
+  equal(input.val(), "", "format the value of the field on focus");
+});
+
+test("with treatEmptyAsZero set to true and allowZero set to true", function() {
+  var input = $("#input1").maskMoney({allowZero: true, treatEmptyAsZero: true});
+  input.val("");
+  input.trigger("focus");
+  input.trigger("blur");
+  equal(input.val(), "0.00", "format the value of the field on focus");
+});
+
+test("with treatEmptyAsZero set to true and allowZero set to false", function() {
+  var input = $("#input1").maskMoney({allowZero: false, treatEmptyAsZero: true});
+  input.val("");
+  input.trigger("focus");
+  input.trigger("blur");
+  equal(input.val(), "", "format the value of the field on focus");
+});
+
+test("with treatEmptyAsZero set to false and allowZero set to true", function() {
+  var input = $("#input1").maskMoney({allowZero: true, treatEmptyAsZero: false});
+  input.val("");
+  input.trigger("focus");
+  input.trigger("blur");
+  equal(input.val(), "", "format the value of the field on focus");
+});
+
+test("with treatEmptyAsZero set to false and allowZero set to true, a zero input should be 0", function() {
+  var input = $("#input1").maskMoney({allowZero: true, treatEmptyAsZero: false});
+  input.trigger("focus");
+  input.val("0.00");
+  input.trigger("blur");
+  equal(input.val(), "0.00", "format the value of the field on focus");
+});
+
+test("with treatEmptyAsZero set to false and allowZero set to false", function() {
+  var input = $("#input1").maskMoney({allowZero: false, treatEmptyAsZero: false});
+  input.val("");
+  input.trigger("focus");
+  input.trigger("blur");
+  equal(input.val(), "", "format the value of the field on focus");
+});
+

--- a/test/focus_test.js
+++ b/test/focus_test.js
@@ -7,3 +7,32 @@ test("with default mask", function() {
     input.trigger("focus");
     equal(input.val(), "123,456.78", "format the value of the field on focus");
 });
+
+test("with treatEmptyAsZero set to true", function() {
+  var input = $("#input1").maskMoney({treatEmptyAsZero: true});
+  input.val("");
+  input.trigger("focus");
+  equal(input.val(), "0.00", "format the value of the field on focus");
+});
+
+test("with treatEmptyAsZero set to false", function() {
+  var input = $("#input1").maskMoney({treatEmptyAsZero: false});
+  input.val("");
+  input.trigger("focus");
+  equal(input.val(), "", "format the value of the field on focus");
+});
+
+test("with treatEmptyAsZero set to false with space input", function() {
+  var input = $("#input1").maskMoney({treatEmptyAsZero: false});
+  input.val(" ");
+  input.trigger("focus");
+  equal(input.val(), "", "format the value of the field on focus");
+});
+
+
+test("with treatEmptyAsZero set to false and allowZero set to true", function() {
+  var input = $("#input1").maskMoney({allowZero: true, treatEmptyAsZero: false});
+  input.val("");
+  input.trigger("focus");
+  equal(input.val(), "", "format the value of the field on focus");
+});

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,7 @@
 	<script src="data_dash_test.js"></script>
 	<script src="unmasked_test.js"></script>
 	<script src="focus_test.js"></script>
+	<script src="blur_test.js"></script>
 	<script src="change_test.js"></script>
 	<script src="keypress_test.js"></script>
 	<script src="cut_paste_test.js"></script>

--- a/test/keypress_test.js
+++ b/test/keypress_test.js
@@ -12,3 +12,20 @@ test("format the field value", function() {
 
     equal(input.val(), "1,234.56", "format the value of the field on focus");
 });
+
+// Couldn't get this test working. If you can, please do:
+//test("backspace should persist mask", function() {
+//    var input = $("#input1").maskMoney();
+//    keypress(input, 1);
+//    keypress(input, 2);
+//    keypress(input, 3);
+//    keypress(input, 4);
+//    keypress(input, 5);
+//    keypress(input, 6);
+//    keypress(input, 7);
+//    keypress(input, 8);
+//    equal(input.val(), "123,456.78", "format the value of the field on focus");
+//    keypress(input, 'backspace');
+//    keypress(input, 'backspace');
+//    equal(input.val(), "1,234.56", "format the value of the field on focus");
+//});


### PR DESCRIPTION
This pull request adds a new option to the library: `treatEmptyAsZero`.

Currently in this library, when focusing on an empty field, the masking library assumes the user intends "blank" to mean 0. I needed empty to mean "nothing" and allow the user to specify either "nothing" or 0 as the submitted value.

Here, setting `treatEmptyAsZero` to `false` allows you to delete a `0.00` masked value and allows the user to enter either a blank input or zero.
