### PR TITLE
Adding bower.json so that build scripts dependent on the main attribute still work.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,9 @@
+{
+  "name": "jquery-maskmoney",
+  "version": "3.0.2",
+  "authors": [
+    "Diego Plentz"
+  ],
+  "main": "dist/jquery.maskMoney.js",
+  "license": "MIT"
+}

--- a/bower.json
+++ b/bower.json
@@ -5,5 +5,6 @@
     "Diego Plentz"
   ],
   "main": "dist/jquery.maskMoney.js",
-  "license": "MIT"
+  "license": "MIT",
+  "ignore" : []
 }


### PR DESCRIPTION
Many people are using your bower listing to include this awesome library into their projects, however, the repo has no `bower.json`.

This means that people who count on it being there for build scripts cannot use it as a true bower style dependency.

Usually, when a person wants to make a repo on bower, they run `bower init` This creates the `bower.json` with reasonable defaults. It is something that users count on being there. 

Addition of a `bower.json`, and in particular, the `main` attribute of the `bower.json`, ensures that people can use npm's like [main bower files](https://github.com/ck86/main-bower-files) to compile their source code without configuring which file is the actual source file in the repo.

The only issues I can think of by adding this are:
1. You will need to bump the version number in the `bower.json` when you make a new release.
2. You might want to point the `main` attribute at the minified version instead.

If you accept this pull request you will also need to make a version bump. A patch bump will be sufficient.