### PR TITLE
fix the mask precision issue.

### DIFF
--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -194,7 +194,7 @@
 
                 function mask() {
                     var value = $input.val();
-                    value = value.replace(/[^\-0-9\.]/g, '');
+                    value = value.replace(/[^\-0-9\.]/g, "");
                     value = Number(value).toFixed(settings.precision);
 
                     $input.val(maskValue(value));

--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -117,7 +117,6 @@
                             }
                         }
                     }
-
                     return {
                         start: start,
                         end: end
@@ -180,6 +179,7 @@
                         leadingZeros = new Array((settings.precision + 1) - decimalPart.length).join(0);
                         newValue += settings.decimal + leadingZeros + decimalPart;
                     }
+
                     return setSymbol(newValue);
                 }
 
@@ -194,6 +194,9 @@
 
                 function mask() {
                     var value = $input.val();
+                    value = value.replace(/[^0-9\.]/g, '');
+                    value = Number(value).toFixed(settings.precision);
+
                     $input.val(maskValue(value));
                 }
 
@@ -261,6 +264,7 @@
                         selection = getInputSelection();
                         startPos = selection.start;
                         endPos = selection.end;
+
                         value = $input.val();
                         $input.val(value.substring(0, startPos) + keyPressedChar + value.substring(endPos, value.length));
                         maskAndPosition(startPos + 1);

--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -194,7 +194,7 @@
 
                 function mask() {
                     var value = $input.val();
-                    value = value.replace(/[^0-9\.]/g, '');
+                    value = value.replace(/[^\-0-9\.]/g, '');
                     value = Number(value).toFixed(settings.precision);
 
                     $input.val(maskValue(value));

--- a/test/cut_paste_test.js
+++ b/test/cut_paste_test.js
@@ -7,7 +7,7 @@ module("cut & paste");
 test("when cuting", function() {
     stop();
     var input = $("#input1").maskMoney();
-    input.val("12345678");
+    input.val("123456.78");
     input.trigger("cut");
     setTimeout( function() {
         start();
@@ -18,7 +18,7 @@ test("when cuting", function() {
 test("when pasting", function() {
     stop();
     var input = $("#input1").maskMoney();
-    input.val("12345678");
+    input.val("123456.78");
     input.trigger("paste");
     setTimeout( function() {
         start();

--- a/test/data_dash_test.js
+++ b/test/data_dash_test.js
@@ -3,7 +3,7 @@
 module("data-dash api");
 test("with field configured using data-* attributes", function() {
     var input = $("#input3").maskMoney();
-    input.val("12345678");
+    input.val("123.45678");
     input.trigger("focus");
     equal(input.val(), "R$123.456,78", "configure maskMoney using data-* attributes");
 });

--- a/test/data_dash_test.js
+++ b/test/data_dash_test.js
@@ -3,7 +3,7 @@
 module("data-dash api");
 test("with field configured using data-* attributes", function() {
     var input = $("#input3").maskMoney();
-    input.val("123.45678");
+    input.val("123456.78");
     input.trigger("focus");
     equal(input.val(), "R$123.456,78", "configure maskMoney using data-* attributes");
 });

--- a/test/focus_test.js
+++ b/test/focus_test.js
@@ -3,7 +3,7 @@
 module("focus");
 test("with default mask", function() {
     var input = $("#input1").maskMoney();
-    input.val("12345678");
+    input.val("123456.78");
     input.trigger("focus");
     equal(input.val(), "123,456.78", "format the value of the field on focus");
 });

--- a/test/mask_test.js
+++ b/test/mask_test.js
@@ -12,14 +12,14 @@ test("with a lot of leading zeroes", function() {
     var input = $("#input1").maskMoney();
     input.val("000000000123");
     input.maskMoney("mask");
-    equal(input.val(), "1.23", "removes the unecessary zeroes");
+    equal(input.val(), "123.00", "removes the unecessary zeroes");
 });
 
 test("with negative symbol and a field that doesn't allow negative ", function() {
     var input = $("#input1").maskMoney({allowNegative: false});
     input.val("-123");
     input.maskMoney("mask");
-    equal(input.val(), "1.23", "removes negative symbol");
+    equal(input.val(), "123.00", "removes negative symbol");
 });
 
 test("with a number as parameter", function() {


### PR DESCRIPTION
if value is 1, 1.0, 0.1, and the precision is 2, it always mask the value incorrect.

So before mask the value, format the original value in to the configuration precision, then trigger the maskValue method to format it.