### PR TITLE
Fix format on unprecision value

### DIFF
--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -159,6 +159,16 @@
                 }
 
                 function maskValue(value) {
+                    if (settings.precision > 0 && value.indexOf(settings.decimal) < 0) {
+                        /*
+                         * if the value come without the precisian value add zeros to prevent the format mistake
+                         * before: 10 become 0.10, now: 10 become 10.00
+                         */
+                        for (var i = 0; i < settings.precision; i++) {
+                            value += "0";
+                        }
+                    }
+
                     var negative = (value.indexOf("-") > -1 && settings.allowNegative) ? "-" : "",
                         onlyNumbers = value.replace(/[^0-9]/g, ""),
                         integerPart = onlyNumbers.slice(0, onlyNumbers.length - settings.precision),


### PR DESCRIPTION
If the value come without the precisian value add zeros to prevent the format mistake