### PR TITLE
Allow no decimals 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The options that you can set are:
  * `precision`: how many decimal places are allowed. default: 2
  * `allowZero`: use this setting to prevent users from inputing zero. default: false
  * `allowNegative`: use this setting to prevent users from inputing negative values. default: false
+ * `allowNoDecimal`: use this setting to allow decimal portions to be triggered manually by the user (in conjunction with thousands and decimal properties - make sure they are unique). default: false
 
 __IMPORTANT__: if you try to bind maskMoney to a read only field, nothing will happen, since we ignore completely read only fields. So, if you have a read only field, try to bind maskMoney to it, it will not work. Even if you change the field removing the readonly property, you will need to re-bind maskMoney to make it work.
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -58,6 +58,11 @@
 			var num = $('#demo8').maskMoney('unmasked')[0];
 			alert('type: '+ typeof(num) + ', value: ' + num)
 		</pre>
+
+		<input type="text" id="demo9"/>
+		<script type="text/javascript">$("#demo9").maskMoney({ enforceDecimal: false });</script>
+		<pre class="brush: js">$("#demo9").maskMoney({ enforceDecimal: false });</pre>
+
 	</body>
 	<script type="text/javascript">
 		SyntaxHighlighter.all()

--- a/demo/index.html
+++ b/demo/index.html
@@ -60,8 +60,8 @@
 		</pre>
 
 		<input type="text" id="demo9"/>
-		<script type="text/javascript">$("#demo9").maskMoney({ enforceDecimal: false });</script>
-		<pre class="brush: js">$("#demo9").maskMoney({ enforceDecimal: false });</pre>
+		<script type="text/javascript">$("#demo9").maskMoney({ enforceDecimal: false, precision: 2 });</script>
+		<pre class="brush: js">$("#demo9").maskMoney({ enforceDecimal: false, precision: 2 });</pre>
 
 	</body>
 	<script type="text/javascript">

--- a/demo/index.html
+++ b/demo/index.html
@@ -60,13 +60,13 @@
 		</pre>
 
 		<input type="text" id="demo9"/>
-		<script type="text/javascript">$("#demo9").maskMoney({ enforceDecimal: false });</script>
-		<pre class="brush: js">$("#demo9").maskMoney({ enforceDecimal: false});</pre>
+		<script type="text/javascript">$("#demo9").maskMoney({ allowNoDecimal: true });</script>
+		<pre class="brush: js">$("#demo9").maskMoney({ allowNoDecimal: false});</pre>
 
-		<input type="text" id="demo10" data-thousands="." data-decimal="," data-prefix="AUD$ " data-enforce-decimal="false" data-precision="4" />
+		<input type="text" id="demo10" data-thousands="." data-decimal="," data-prefix="AUD$ " data-allow-no-decimal="true" data-precision="4" />
 		<script type="text/javascript">$("#demo10").maskMoney();</script>
 		<pre class="brush: js">$("#demo10").maskMoney();</pre>
-		<pre class="brush: html"><input type="text" id="demo10" data-thousands="." data-decimal="," data-prefix="AUD$ " data-enforce-decimal="false" data-precision="4" /></pre>
+		<pre class="brush: html"><input type="text" id="demo10" data-thousands="." data-decimal="," data-prefix="AUD$ " data-allow-no-decimal="false" data-precision="4" /></pre>
 
 	</body>
 	<script type="text/javascript">

--- a/demo/index.html
+++ b/demo/index.html
@@ -60,8 +60,13 @@
 		</pre>
 
 		<input type="text" id="demo9"/>
-		<script type="text/javascript">$("#demo9").maskMoney({ enforceDecimal: false, precision: 2 });</script>
-		<pre class="brush: js">$("#demo9").maskMoney({ enforceDecimal: false, precision: 2 });</pre>
+		<script type="text/javascript">$("#demo9").maskMoney({ enforceDecimal: false });</script>
+		<pre class="brush: js">$("#demo9").maskMoney({ enforceDecimal: false});</pre>
+
+		<input type="text" id="demo10" data-thousands="." data-decimal="," data-prefix="AUD$ " data-enforce-decimal="false" data-precision="4" />
+		<script type="text/javascript">$("#demo10").maskMoney();</script>
+		<pre class="brush: js">$("#demo10").maskMoney();</pre>
+		<pre class="brush: html"><input type="text" id="demo10" data-thousands="." data-decimal="," data-prefix="AUD$ " data-enforce-decimal="false" data-precision="4" /></pre>
 
 	</body>
 	<script type="text/javascript">

--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -192,9 +192,13 @@
                         ) || "0"; // if empty string, return "0" 
                     };
 
+                    var normalize = function(str) {
+                        return str.replace(/[^0-9]/g, "");
+                    }
+
                     // split the number up according to precision
                     if(settings.enforceDecimal) {
-                        var onlyNumbers = value.replace(/[^0-9]/g, "");
+                        var onlyNumbers = normalize(value);
 
                         integerPart = onlyNumbers.slice(0, onlyNumbers.length - settings.precision);
                         decimalPart = onlyNumbers.slice(onlyNumbers.length - settings.precision);
@@ -210,14 +214,16 @@
                     } else {
                         var decimalIndex = value.indexOf(settings.decimal);
                         
-                        integerPart = (decimalIndex > -1 ? value.slice(0, decimalIndex) : value).replace(/[^0-9]/g, "");
-                        decimalPart = (decimalIndex > 0 ? value.slice(decimalIndex, decimalIndex + settings.precision + 1) : "");
+                        integerPart = (decimalIndex > -1 ? value.slice(0, decimalIndex) : value);
+                        decimalPart = (decimalIndex > -1 ? value.slice(decimalIndex + 1) : "");
+                        integerPart = normalize(integerPart);
+                        decimalPart = normalize(decimalPart).slice(0, settings.precision);
 
                         newValue = thousandify(integerPart);
 
                         // only replace the decimal part if it exists 
                         if(decimalIndex > -1) {
-                            newValue += decimalPart;
+                            newValue += settings.decimal + decimalPart;
                         }
                     }
 
@@ -239,7 +245,7 @@
 
                 function mask() {
                     var value = $input.val();
-                    if (settings.precision > 0 && value.indexOf(settings.decimal) < 0) {
+                    if (settings.enforceDecimal && settings.precision > 0 && value.indexOf(settings.decimal) < 0) {
                         value += settings.decimal + new Array(settings.precision+1).join(0);
                     }
                     $input.val(maskValue(value));

--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -58,7 +58,8 @@
                 decimal: ".",
                 precision: 2,
                 allowZero: false,
-                allowNegative: false
+                allowNegative: false,
+                enforceDecimal: true
             }, parameters);
 
             return this.each(function () {

--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -147,7 +147,7 @@
                         return false;
                     }
 
-                    var decimalIndex = $input.val().indexOf();
+                    var decimalIndex = $input.val().indexOf(settings.decimal);
                     var hasDecimal = decimalIndex > -1;
 
                     return !hasDecimal;
@@ -299,8 +299,17 @@
                         } else if (key === 13 || key === 9) {
                             return true;
                         // accept the decimal key IF enforceDecimal is false
-                        } else if (key === settings.decimal.codePointAt()) {
-                            return canInputDecimal();
+                        } else if (key === settings.decimal.codePointAt() && canInputDecimal()) {
+                            preventDefault(e);
+
+                            keyPressedChar = String.fromCharCode(key);
+                            selection = getInputSelection();
+                            startPos = selection.start;
+                            endPos = selection.end;
+                            value = $input.val();
+                            $input.val(value.substring(0, startPos) + keyPressedChar + value.substring(endPos, value.length));
+                            maskAndPosition(startPos + 1);
+                            return false;
                         } else if ($.browser.mozilla && (key === 37 || key === 39) && e.charCode === 0) {
                             // needed for left arrow key or right arrow key with firefox
                             // the charCode part is to avoid allowing "%"(e.charCode 0, e.keyCode 37)

--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -211,12 +211,12 @@
                         var decimalIndex = value.indexOf(settings.decimal);
                         
                         integerPart = (decimalIndex > -1 ? value.slice(0, decimalIndex) : value).replace(/[^0-9]/g, "");
-                        decimalPart = (decimalIndex > 0 ? value.slice(decimalIndex) : "");
+                        decimalPart = (decimalIndex > 0 ? value.slice(decimalIndex, decimalIndex + settings.precision + 1) : "");
 
                         newValue = thousandify(integerPart);
 
                         // only replace the decimal part if it exists 
-                        if(decimalIndex > 0) {
+                        if(decimalIndex > -1) {
                             newValue += decimalPart;
                         }
                     }

--- a/test/index.html
+++ b/test/index.html
@@ -16,6 +16,7 @@
 	<script src="change_test.js"></script>
 	<script src="typing_test.js"></script>
 	<script src="cut_paste_test.js"></script>
+	<script src="optional_decimals_test.js"></script>
 </head>
 <body>
     <div id="qunit"></div>

--- a/test/optional_decimals_test.js
+++ b/test/optional_decimals_test.js
@@ -4,7 +4,7 @@ module("optional decimals");
 
 test('testing basic entry with unenforced decimals',function() {
     var input = $("#input1").maskMoney({ 
-        enforceDecimal: false
+        allowNoDecimal: true
     });
 
     input.trigger("focus");
@@ -30,7 +30,7 @@ test('testing basic entry with unenforced decimals',function() {
 
 test('testing basic entries with unenforced decimals and variable precision',function() {
     var input = $("#input1").maskMoney({ 
-        enforceDecimal: false,
+        allowNoDecimal: true,
         precision: 3
     });
 
@@ -61,7 +61,7 @@ test('testing basic entries with unenforced decimals and variable precision',fun
 
 test('testing prefilled entries with unenforced decimals',function() {
     var input = $("#input1").maskMoney({ 
-        enforceDecimal: false 
+        allowNoDecimal: true 
     });
 
     input.val("1234567.890");
@@ -72,7 +72,7 @@ test('testing prefilled entries with unenforced decimals',function() {
 
 test('testing prefilled entries with unenforced decimals and variable precision',function() {
     var input = $("#input1").maskMoney({ 
-        enforceDecimal: false,
+        allowNoDecimal: true,
         precision: 3 
     });
 

--- a/test/optional_decimals_test.js
+++ b/test/optional_decimals_test.js
@@ -1,0 +1,88 @@
+"use strict";
+
+module("optional decimals");
+
+test('testing basic entry with unenforced decimals',function() {
+    var input = $("#input1").maskMoney({ 
+        enforceDecimal: false
+    });
+
+    input.trigger("focus");
+    keypress(input, 1);
+    keypress(input, 2);
+    keypress(input, 3);
+    keypress(input, 4);
+    keypress(input, 5);
+    keypress(input, 6);
+    keypress(input, 7);
+
+    equal(input.val(), "1,234,567", "accept the input and format correctly");
+
+    // no idea why this doesn't work. so I'm hacking around it to simulate keypress
+    // keypress(input, ".");
+    input.val(input.val() + '.');
+    keypress(input, 8);
+    keypress(input, 9);
+    keypress(input, 0);
+
+    equal(input.val(), "1,234,567.89", "accept the input and format correctly");
+});
+
+test('testing basic entries with unenforced decimals and variable precision',function() {
+    var input = $("#input1").maskMoney({ 
+        enforceDecimal: false,
+        precision: 3
+    });
+
+    input.trigger("focus");
+    keypress(input, 1);
+    keypress(input, 2);
+    keypress(input, 3);
+    keypress(input, 4);
+    keypress(input, 5);
+    keypress(input, 6);
+    keypress(input, 7);
+
+    equal(input.val(), "1,234,567", "accept the input and format correctly");
+
+    // no idea why this doesn't work. so I'm hacking around it to simulate keypress
+    // keypress(input, ".");
+    input.val(input.val() + '.');
+    keypress(input, 8);
+    keypress(input, 9);
+    keypress(input, 0);
+
+    equal(input.val(), "1,234,567.890", "accept the input and format correctly");
+
+    keypress(input, 1);
+
+    equal(input.val(), "1,234,567.890", "accept the input and format correctly");
+});
+
+test('testing prefilled entries with unenforced decimals',function() {
+    var input = $("#input1").maskMoney({ 
+        enforceDecimal: false 
+    });
+
+    input.val("1234567.890");
+    input.trigger("focus");
+
+    equal(input.val(), "1,234,567.89", "accept the input and format correctly");
+});
+
+test('testing prefilled entries with unenforced decimals and variable precision',function() {
+    var input = $("#input1").maskMoney({ 
+        enforceDecimal: false,
+        precision: 3 
+    });
+
+    input.val("1234567.890");
+    input.trigger("focus");
+
+    equal(input.val(), "1,234,567.890", "accept the input and format correctly");
+
+    input.val("1234567.8901");
+    input.trigger("focus");
+
+    equal(input.val(), "1,234,567.890", "accept the input and format correctly");
+});


### PR DESCRIPTION
In reference to #82.

This feature turned up in one of my client work today, so I figured I'd try to implement it myself (spare time, unsponsored :( )

This patch introduces the allowNoDecimal property (false by default).

By turning it on the follow semantics apply:

 - values are initially treated as integer
 - any numbers added are automatically thousand'd.
 - the first time a decimal is placed, the number is now treated as a float
 - you may add up to <precision> number of digits after the decimal
 - if adding a decimal, or masking an existing value, causes an over-precision, the rest are discarded.
 
Both the precision and the decimal properties influences this behaviour (so if decimal is changed to ",", the "," key must be used to start decimals).

I hope these semantics make sense, as I will be using these in my client project.

I have also updated the Readme, the demo html, as well as introduced 4 new tests for testing this behaviour. Unfortunately I could not get "." and cursor keypresses to work in the test :( if you let me know how to get them to work, I'll add more tests.

Kind Regards,
Daryl
