### PR TITLE
Allow empty input if allowZero is set to false

### DIFF
--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -195,7 +195,11 @@
                     if (settings.precision > 0 && value.indexOf(settings.decimal) < 0) {
                         value += settings.decimal + new Array(settings.precision+1).join(0);
                     }
-                    $input.val(maskValue(value));
+                    if (settings.allowZero || $.isNumeric(value)) {
+                        $input.val(maskValue(value));
+                    } else {
+                        $input.val('');
+                    }
                 }
 
                 function changeSign() {


### PR DESCRIPTION
Allow empty input if allowZero is set to false, so that if we have set a placeholder, by default the browsers will display it.