### PR TITLE
Allow empty input if allowZero is set to false

### DIFF
--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -198,7 +198,7 @@
                     if (settings.allowZero || $.isNumeric(value)) {
                         $input.val(maskValue(value));
                     } else {
-                        $input.val('');
+                        $input.val("");
                     }
                 }
 


### PR DESCRIPTION
Allow empty input if allowZero is set to false, so that if we have set a placeholder, by default the browsers will display it.

Fixes #185 
