### PR TITLE
changed mangle except to reserved

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
             options: {
                 banner: "<%= meta.banner %>",
                 mangle: {
-                    except: ["jQuery", "$"]
+                    reserved: ["jQuery", "$"]
                 }
             },
             build: {


### PR DESCRIPTION
_Gruntfile_ changed uglify mangle from _except_ to _reserved_ because with _except_ an exception is generated when _npm run build_.

```bash
message: '`except` is not a supported option',
  defs:
   { cache: null,
     eval: false,
     ie8: false,
     keep_fnames: false,
     properties: false,
     reserved: [],
     toplevel: false } }
>> Uglifying source src/jquery.maskMoney.js failed.
Warning: Uglification failed.
`except` is not a supported option.
 Use --force to continue.

Aborted due to warnings.
```