### PR TITLE
patch in mask function when thousands separator may be different from…

### DIFF
--- a/src/jquery.maskMoney.js
+++ b/src/jquery.maskMoney.js
@@ -202,8 +202,7 @@
                     if (settings.allowEmpty && value === "") {
                         return;
                     }
-                    var isNumber = !isNaN(value);
-					var decimalPointIndex = isNumber? value.indexOf("."): value.indexOf(settings.decimal);
+					var decimalPointIndex = value.indexOf(settings.decimal);
                     if (settings.precision > 0) {
 						if(decimalPointIndex < 0){
 							value += settings.decimal + new Array(settings.precision + 1).join(0);


### PR DESCRIPTION
For this section:
```
var isNumber = !isNaN(value);
var decimalPointIndex = isNumber? value.indexOf("."): value.indexOf(settings.decimal);
```

Whereas:
settings.decimal = ',';
value = '100.000';

Currently the value calculated by `function mask ()` is 100. It should be 100000.

Even if `value` is considered numeric, we can not consider the first '.' being a decimal separator. I always recommend using `settings.decimal`.

I'm sending you a patch suggestion.