### PR TITLE
Fixes broken test on destroy method

### DIFF
--- a/test/init_and_destroy_test.js
+++ b/test/init_and_destroy_test.js
@@ -22,5 +22,13 @@ test("destroy", function() {
         events;
     input.maskMoney("destroy");
     events = jQuery._data(input.get(0), "events");
-    equal(events, undefined, "destroy method removed all attached events");
+
+    var eventsWithMaskMoneyNamespace = events;
+    if (eventsWithMaskMoneyNamespace !== undefined) {
+        eventsWithMaskMoneyNamespace = Object.values(events).flat().find(function (event) {
+            return event.namespace === "maskMoney";
+        });
+    }
+
+    equal(eventsWithMaskMoneyNamespace, undefined, "destroy method removed all attached events");
 });


### PR DESCRIPTION
Hi, the test on destroy method expects to all events to be removed and the value to be undefined, but seems that jquery is registering its events also, which leads to unexpected result and broken test.

I made a filter on the test to test only the maskMoney namespaced events.
